### PR TITLE
Include Caching of Deposit Data

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
@@ -63,4 +63,11 @@ container_push(
     tag = "{DOCKER_TAG}",
     tags = ["manual"],
     visibility = ["//visibility:private"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["keystore_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//eth1:go_default_library"],
 )

--- a/keystore.go
+++ b/keystore.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"io/ioutil"
 
 	"github.com/prysmaticlabs/eth1-mock-rpc/eth1"
 	"github.com/prysmaticlabs/prysm/shared/keystore"
@@ -12,7 +13,6 @@ import (
 const (
 	withdrawalPrivkeyFileName = "/shardwithdrawalkey"
 	validatorPrivkeyFileName  = "/validatorprivatekey"
-	cacheDirector             = ".cache"
 )
 
 func createDepositDataFromKeystore(directory string, password string) ([]*eth1.DepositData, error) {
@@ -53,12 +53,12 @@ func createDepositDataFromKeystore(directory string, password string) ([]*eth1.D
 }
 
 func retrieveDepositData(r io.Reader) ([]*eth1.DepositData, error) {
-	encodedData := []byte{}
-	if _, err := r.Read(encodedData); err != nil {
+	encodedData, err := ioutil.ReadAll(r)
+	if err != nil {
 		return nil, err
 	}
 	var deposits []*eth1.DepositData
-	if err := json.Unmarshal(encodedData, deposits); err != nil {
+	if err := json.Unmarshal(encodedData, &deposits); err != nil {
 		return nil, err
 	}
 	return deposits, nil

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -1,7 +1,47 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/prysmaticlabs/eth1-mock-rpc/eth1"
+)
+
+type mockWriter struct {
+	encoded []byte
+}
+
+func (w *mockWriter) Write(b []byte) (int, error) {
+	w.encoded = b
+	return len(w.encoded), nil
+}
 
 func TestRoundTripRetrieveDepositData(t *testing.T) {
-
+	deposits := []*eth1.DepositData{
+		{
+			Pubkey:                []byte{1, 2, 3, 4, 5},
+			WithdrawalCredentials: []byte{6, 7, 8, 9, 10},
+			Amount:                32,
+			Signature:             make([]byte, 96),
+		},
+		{
+			Pubkey:                []byte{9, 9, 9, 9},
+			WithdrawalCredentials: []byte{8, 8, 8, 8},
+			Amount:                40,
+			Signature:             make([]byte, 96),
+		},
+	}
+	w := &mockWriter{}
+	if err := persistDepositData(w, deposits); err != nil {
+		t.Fatal(err)
+	}
+	buf := bytes.NewBuffer(w.encoded)
+	parsedDeposits, err := retrieveDepositData(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(deposits, parsedDeposits) {
+		t.Errorf("Original deposits = %v, received = %v", deposits, parsedDeposits)
+	}
 }

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestRoundTripRetrieveDepositData(t *testing.T) {
+
+}

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 	if r, err := os.Open(cachePath); err == nil {
 		deposits, err = retrieveDepositData(r)
 		if err != nil {
-			log.Fatalf("Could not retrieve deposits from .cache: %v", err)
+			log.Fatalf("Could not retrieve deposits from %s: %v", cachePath, err)
 		}
 	} else if os.IsNotExist(err) {
 		// If the file does not exist at the .cache directory, we decrypt
@@ -74,7 +74,7 @@ func main() {
 			log.Errorf("Could not persist deposits to disk: %v", err)
 		}
 	} else {
-		log.Fatalf("Could not read from .cache directory: %v", err)
+		log.Fatalf("Could not read from %s: %v", cachePath, err)
 	}
 
 	log.Infof("Successfully loaded %d deposits from the keystore directory", len(deposits))

--- a/main.go
+++ b/main.go
@@ -12,8 +12,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
-
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/prysmaticlabs/eth1-mock-rpc/eth1"
 	"github.com/sirupsen/logrus"
@@ -32,7 +30,6 @@ var (
 	wsPort                = flag.String("ws-port", "7778", "Port on which to serve websocket listeners")
 	httpPort              = flag.String("http-port", "7777", "Port on which to serve http listeners")
 	log                   = logrus.WithField("prefix", "main")
-	cacheDirectory        = ".cache"
 	persistedDepositsJSON = "deposits.json"
 )
 
@@ -51,8 +48,8 @@ func main() {
 	logrus.SetFormatter(formatter)
 
 	var deposits []*eth1.DepositData
-	cachePath := path.Join(bazel.RUNFILES_DIR, cacheDirectory, persistedDepositsJSON)
-
+	tmp := os.TempDir()
+	cachePath := path.Join(tmp, persistedDepositsJSON)
 	// We attempt to retrieve deposits from a local .cache/ directory
 	// as an optimization to prevent reading and decrypting raw private keys
 	// from the validator keystore every single time the mock server is launched.

--- a/main.go
+++ b/main.go
@@ -8,7 +8,11 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"path"
 	"time"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
 
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/prysmaticlabs/eth1-mock-rpc/eth1"
@@ -23,11 +27,13 @@ const (
 )
 
 var (
-	keystorePath = flag.String("keystore-path", "", "Path to a validator keystore directory")
-	password     = flag.String("password", "", "Password to unlocking the validator keystore directory")
-	wsPort       = flag.String("ws-port", "7778", "Port on which to serve websocket listeners")
-	httpPort     = flag.String("http-port", "7777", "Port on which to serve http listeners")
-	log          = logrus.WithField("prefix", "main")
+	keystorePath          = flag.String("keystore-path", "", "Path to a validator keystore directory")
+	password              = flag.String("password", "", "Password to unlocking the validator keystore directory")
+	wsPort                = flag.String("ws-port", "7778", "Port on which to serve websocket listeners")
+	httpPort              = flag.String("http-port", "7777", "Port on which to serve http listeners")
+	log                   = logrus.WithField("prefix", "main")
+	cacheDirectory        = ".cache"
+	persistedDepositsJSON = "deposits.json"
 )
 
 type server struct {
@@ -44,13 +50,37 @@ func main() {
 	formatter.FullTimestamp = true
 	logrus.SetFormatter(formatter)
 
-	log.Infof("Parsing and decrypting private keys from %s, this may take a while...", *keystorePath)
-	deposits, err := createDepositDataFromKeystore(*keystorePath, *password)
-	if err != nil {
-		log.Fatalf("Could not create deposit data from keystore directory: %v", err)
-	}
-	log.Infof("Successfully loaded %d deposits from the keystore directory", len(deposits))
+	var deposits []*eth1.DepositData
+	cachePath := path.Join(bazel.RUNFILES_DIR, cacheDirectory, persistedDepositsJSON)
 
+	// We attempt to retrieve deposits from a local .cache/ directory
+	// as an optimization to prevent reading and decrypting raw private keys
+	// from the validator keystore every single time the mock server is launched.
+	if r, err := os.Open(cachePath); err == nil {
+		deposits, err = retrieveDepositData(r)
+		if err != nil {
+			log.Fatalf("Could not retrieve deposits from .cache: %v", err)
+		}
+	} else if os.IsNotExist(err) {
+		// If the file does not exist at the .cache directory, we decrypt
+		// from the keystore directory and then attempt to persist to the cache.
+		log.Infof("Decrypting private keys from %s, this may take a while...", *keystorePath)
+		deposits, err = createDepositDataFromKeystore(*keystorePath, *password)
+		if err != nil {
+			log.Fatalf("Could not create deposit data from keystore directory: %v", err)
+		}
+		w, err := os.Create(cachePath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := persistDepositData(w, deposits); err != nil {
+			log.Errorf("Could not persist deposits to disk: %v", err)
+		}
+	} else {
+		log.Fatalf("Could not read from .cache directory: %v", err)
+	}
+
+	log.Infof("Successfully loaded %d deposits from the keystore directory", len(deposits))
 	httpListener, err := net.Listen("tcp", fmt.Sprintf("localhost:%s", *httpPort))
 	if err != nil {
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	var deposits []*eth1.DepositData
 	tmp := os.TempDir()
 	cachePath := path.Join(tmp, persistedDepositsJSON)
-	// We attempt to retrieve deposits from a local .cache/ directory
+	// We attempt to retrieve deposits from a local tmp file
 	// as an optimization to prevent reading and decrypting raw private keys
 	// from the validator keystore every single time the mock server is launched.
 	if r, err := os.Open(cachePath); err == nil {
@@ -59,7 +59,7 @@ func main() {
 			log.Fatalf("Could not retrieve deposits from %s: %v", cachePath, err)
 		}
 	} else if os.IsNotExist(err) {
-		// If the file does not exist at the .cache directory, we decrypt
+		// If the file does not exist at the tmp directory, we decrypt
 		// from the keystore directory and then attempt to persist to the cache.
 		log.Infof("Decrypting private keys from %s, this may take a while...", *keystorePath)
 		deposits, err = createDepositDataFromKeystore(*keystorePath, *password)

--- a/main.go
+++ b/main.go
@@ -160,14 +160,12 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *server) ServeWebsocket() http.Handler {
 	return websocket.Server{
 		Handler: func(conn *websocket.Conn) {
-			log.Info("READING AGAIN FROM WSS")
 			codec := newWebsocketCodec(conn)
 			defer codec.Close()
 			// Listen to read events from the codec and dispatch events or errors accordingly.
 			go s.websocketReadLoop(codec)
 			go s.dispatchWebsocketEventLoop(codec)
 			<-codec.Closed()
-			log.Info("CODEC CLOSED")
 		},
 	}
 }
@@ -181,7 +179,6 @@ func (s *server) dispatchWebsocketEventLoop(codec ServerCodec) {
 	for {
 		select {
 		case <-s.close:
-			log.Info("Closing dispatch loop")
 			return
 		case err := <-s.readErr:
 			log.WithError(err).Error("Could not read data from request")
@@ -214,7 +211,6 @@ func (s *server) websocketReadLoop(codec ServerCodec) {
 	for {
 		select {
 		case <-s.close:
-			log.Info("Closing read loop")
 			return
 		default:
 			msgs, _, err := codec.Read()


### PR DESCRIPTION
A major improvement to be made is to cache the keystore deposits to a /tmp file so there will be no need to parse and decrypt every private key every time the server is restarted. This improves the speed of launching the binary to around 100ms compared to 2 minutes previously.