### PR TITLE
Allow Triggering of New Deposits Through a Console

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -57,6 +57,7 @@ go_image(
     deps = [
         "//eth1:go_default_library",
         "@com_github_ethereum_go_ethereum//rpc:go_default_library",
+        "@com_github_ethereum_go_ethereum//core/types:go_default_library",
         "@com_github_prysmaticlabs_prysm//shared/keystore:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//eth1:go_default_library",
+        "@com_github_ethereum_go_ethereum//core/types:go_default_library",
         "@com_github_ethereum_go_ethereum//rpc:go_default_library",
         "@com_github_prysmaticlabs_prysm//shared/keystore:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/eth1/eth1_handlers.go
+++ b/eth1/eth1_handlers.go
@@ -14,7 +14,6 @@ import (
 // Handler provides methods for handling eth1 JSON-RPC requests using
 // mock or constructed data accordingly.
 type Handler struct {
-	numGenesisDeposits int
 	Deposits           []*DepositData
 }
 
@@ -88,19 +87,19 @@ func (h *Handler) BlockHeaderByNumber() *types.Header {
 // at a deposit contract address. This uses an internal list of deposit data
 // to return instead of relying on a real network and parsing a real deposit contract
 // for this information.
-func (h *Handler) DepositEventLogs() ([]types.Log, error) {
+func DepositEventLogs(deposits []*DepositData) ([]types.Log, error) {
 	depositEventHash := hashutil.HashKeccak256(depositEventSignature)
-	logs := make([]types.Log, len(h.numGenesisDeposits))
+	logs := make([]types.Log, len(deposits))
 	for i := 0; i < len(logs); i++ {
 		indexBuf := make([]byte, 8)
 		amountBuf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(amountBuf, h.Deposits[i].Amount)
+		binary.LittleEndian.PutUint64(amountBuf, deposits[i].Amount)
 		binary.LittleEndian.PutUint64(indexBuf, uint64(i))
 		depositLog, err := packDepositLog(
-			h.Deposits[i].Pubkey,
-			h.Deposits[i].WithdrawalCredentials,
+			deposits[i].Pubkey,
+			deposits[i].WithdrawalCredentials,
 			amountBuf,
-			h.Deposits[i].Signature,
+			deposits[i].Signature,
 			indexBuf,
 		)
 		if err != nil {

--- a/eth1/eth1_handlers.go
+++ b/eth1/eth1_handlers.go
@@ -14,7 +14,8 @@ import (
 // Handler provides methods for handling eth1 JSON-RPC requests using
 // mock or constructed data accordingly.
 type Handler struct {
-	Deposits []*DepositData
+	numGenesisDeposits int
+	Deposits           []*DepositData
 }
 
 // DepositRoot produces a hash tree root of a list of deposits
@@ -89,7 +90,7 @@ func (h *Handler) BlockHeaderByNumber() *types.Header {
 // for this information.
 func (h *Handler) DepositEventLogs() ([]types.Log, error) {
 	depositEventHash := hashutil.HashKeccak256(depositEventSignature)
-	logs := make([]types.Log, len(h.Deposits))
+	logs := make([]types.Log, len(h.numGenesisDeposits))
 	for i := 0; i < len(logs); i++ {
 		indexBuf := make([]byte, 8)
 		amountBuf := make([]byte, 8)

--- a/eth1/eth1_handlers.go
+++ b/eth1/eth1_handlers.go
@@ -11,21 +11,14 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 )
 
-// Handler provides methods for handling eth1 JSON-RPC requests using
-// mock or constructed data accordingly.
-type Handler struct {
-	Deposits           []*DepositData
-}
-
 // DepositRoot produces a hash tree root of a list of deposits
 // to match the output of the deposit contract on the eth1 chain.
-func (h *Handler) DepositRoot() ([32]byte, error) {
-	return ssz.HashTreeRootWithCapacity(h.Deposits, 1<<depositContractTreeDepth)
+func DepositRoot(deposits []*DepositData) ([32]byte, error) {
+	return ssz.HashTreeRootWithCapacity(deposits, 1<<depositContractTreeDepth)
 }
 
 // LatestChainHead returns the latest eth1 chain into a channel.
-// TODO: Convert into a channel push.
-func (h *Handler) LatestChainHead() *types.Header {
+func LatestChainHead() *types.Header {
 	head := &types.Header{
 		ParentHash:  common.Hash([32]byte{}),
 		UncleHash:   types.EmptyUncleHash,
@@ -45,7 +38,7 @@ func (h *Handler) LatestChainHead() *types.Header {
 }
 
 // BlockHeaderByHash returns a block header given a raw hash.
-func (h *Handler) BlockHeaderByHash() *types.Header {
+func BlockHeaderByHash() *types.Header {
 	t := time.Now().Unix()
 	return &types.Header{
 		ParentHash:  common.Hash([32]byte{}),
@@ -65,7 +58,7 @@ func (h *Handler) BlockHeaderByHash() *types.Header {
 }
 
 // BlockHeaderByNumber returns a block header given a block height.
-func (h *Handler) BlockHeaderByNumber() *types.Header {
+func BlockHeaderByNumber() *types.Header {
 	return &types.Header{
 		ParentHash:  common.Hash([32]byte{}),
 		UncleHash:   types.EmptyUncleHash,


### PR DESCRIPTION
## Background 
This PR allows the triggering of new eth2 deposit events via a simple REPL in the eth1-mock-server. It works by taking in the number of genesis deposits, computing all deposits in the keystore, and allowing the user to create `len(allDeposits) - numGenesisDeposits` new deposits.

### Usage 

One can launch the server with:
```bash
bazel run //:eth1-mock-rpc -- \
--keystore-path /path/to/keystore \
--password SOME_PASSWORD_STRING \
--genesis-deposits 64
```

Then, a prompt will occur upon launch:
```bash
INFO main: Enter the number of new eth2 deposits to trigger (max allowed 8):
>> 3
INFO main: Enter the number of new eth2 deposits to trigger (max allowed 5):
```

After entering a valid number, the deposit event will then be triggered in Prysm.

When you launch Prysm, you can specify it to point to this eth1 server using the flags:

```bash
--web3provider ws://localhost:7778 \
--http-web3provider http://localhost:7777
```

**IMPORTANT**: This project caches the initial parsing of private keys from the keystore. If more keys have been added to your keystore, you need to launch the binary with the `--invalidate-cache` flag to recompute the keys.

### Miscellaneous

This PR also improves error handling, adds log verbosity, and makes it so new chainhead events simulate something closer to a real chain, with a constantly increasing block number.