### PR TITLE
Enable PProf and Allow for Multiple Node Connections

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//eth1:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
         "@com_github_ethereum_go_ethereum//rpc:go_default_library",
+        "@com_github_pkg_profile//:go_default_library",
         "@com_github_prysmaticlabs_prysm//shared/keystore:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     deps = [
         "//eth1:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
+        "@com_github_ethereum_go_ethereum//event:go_default_library",
         "@com_github_ethereum_go_ethereum//rpc:go_default_library",
         "@com_github_pkg_profile//:go_default_library",
         "@com_github_prysmaticlabs_prysm//shared/keystore:go_default_library",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -60,6 +60,7 @@ go_image(
         "//eth1:go_default_library",
         "@com_github_ethereum_go_ethereum//rpc:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
+        "@com_github_ethereum_go_ethereum//event:go_default_library",
         "@com_github_prysmaticlabs_prysm//shared/keystore:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -59,6 +59,7 @@ go_image(
     deps = [
         "//eth1:go_default_library",
         "@com_github_ethereum_go_ethereum//rpc:go_default_library",
+        "@com_github_pkg_profile//:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
         "@com_github_ethereum_go_ethereum//event:go_default_library",
         "@com_github_prysmaticlabs_prysm//shared/keystore:go_default_library",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -182,6 +182,12 @@ go_repository(
     importpath = "github.com/deckarep/golang-set",
 )
 
+go_repository(
+    name = "com_github_pkg_profile",
+    commit = "f6fe06335df110bcf1ed6d4e852b760bfc15beee",
+    importpath = "github.com/pkg/profile",
+)
+
 load("@com_github_prysmaticlabs_go_ssz//:deps.bzl", "go_ssz_dependencies")
 
 go_ssz_dependencies()

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var (
 	invalidateCache       = flag.Bool("invalidate-cache", false, "Recalculate deposits into a cache from a keystore")
 	numGenesisDeposits    = flag.Int("genesis-deposits", 0, "Number of deposits to read from the keystore to trigger the genesis event")
 	verbosity             = flag.String("verbosity", "info", "Logging verbosity (debug, info=default, warn, error, fatal, panic)")
+	tracing             = flag.Bool("pprof", false, "Enable pprof tracing")
 	log                   = logrus.WithField("prefix", "main")
 	persistedDepositsJSON = "deposits.json"
 )
@@ -146,7 +147,9 @@ func main() {
 		genesisTime:            uint64(time.Now().Add(10 * time.Second).Unix()),
 	}
 
-	defer profile.Start(profile.MemProfile).Stop()
+	if *tracing {
+		defer profile.Start().Stop()
+	}
 
 	log.Println("Starting HTTP listener on port :7777")
 	go http.Serve(httpListener, srv)

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ var (
 	invalidateCache       = flag.Bool("invalidate-cache", false, "Recalculate deposits into a cache from a keystore")
 	numGenesisDeposits    = flag.Int("genesis-deposits", 0, "Number of deposits to read from the keystore to trigger the genesis event")
 	verbosity             = flag.String("verbosity", "info", "Logging verbosity (debug, info=default, warn, error, fatal, panic)")
-	tracing             = flag.Bool("pprof", false, "Enable pprof tracing")
+	tracing               = flag.Bool("pprof", false, "Enable pprof tracing")
 	log                   = logrus.WithField("prefix", "main")
 	persistedDepositsJSON = "deposits.json"
 )

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("Could not create deposit data from keystore directory: %v", err)
 			}
-			allDeposits = append(allDeposits, dps)
+			allDeposits = append(allDeposits, dps...)
 		}
 		w, err := os.Create(cachePath)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/prysmaticlabs/eth1-mock-rpc/eth1"
+	"github.com/pkg/profile"
 	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 	"golang.org/x/net/websocket"
@@ -130,6 +131,9 @@ func main() {
 		eth1Logs:               logs,
 		genesisTime:            uint64(time.Now().Add(10 * time.Second).Unix()),
 	}
+
+	defer profile.Start(profile.MemProfile).Stop()
+
 	log.Println("Starting HTTP listener on port :7777")
 	go http.Serve(httpListener, srv)
 


### PR DESCRIPTION
This PR enables tracing as well as allowing for multiple node connections. It also allows to read from multiple keystore directories if needed.

## Running

Single keystore
```
bazel run //:eth1-mock-rpc -- \
--keystore-dirs /path/to/keystore \
--keystore-passwords- SOME_PASSWORD_STRING \
--genesis-deposits 64
```
Multiple keystores
```
bazel run //:eth1-mock-rpc -- \
--keystore-dirs /path/to/keystore1,/path/to/keystore2 \
--keystore-passwords- SOME_PASSWORD_STRING,OTHER_PASSWORD_STRING \
--genesis-deposits 64
```

Tracing can be enabled with the `--pprof` flag.