### PR TITLE
Update Dependencies to Fix Sig Verification and Other Bugs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,6 +61,13 @@ load(
 
 _go_image_repos()
 
+git_repository(
+    name = "graknlabs_bazel_distribution",
+    commit = "bd93910450a0f041f5d34a4b97faffcabba21419",
+    remote = "https://github.com/graknlabs/bazel-distribution",
+    shallow_since = "1563544980 +0300",
+)
+
 go_repository(
     name = "com_github_aristanetworks_goarista",
     commit = "728bce664cf5dfb921941b240828f989a2c8f8e3",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -100,19 +100,19 @@ go_repository(
 
 go_repository(
     name = "com_github_prysmaticlabs_go_ssz",
-    commit = "08374e459d08fc6abeb43011a206ad54602e71b6",
+    commit = "9193cae6b7c3347054706b8466db139b8be90985",
     importpath = "github.com/prysmaticlabs/go-ssz",
 )
 
 go_repository(
     name = "com_github_prysmaticlabs_prysm",
-    commit = "0b3ce46d28ad1fd7da62e3cbbe38274c2e48c001",
+    commit = "b4975f2b9d97f2c4035d9924d9e7dd97835f38a6",
     importpath = "github.com/prysmaticlabs/prysm",
 )
 
 go_repository(
     name = "com_github_phoreproject_bls",
-    commit = "b495094dc72c7043b549f511a798391201624b14",
+    commit = "da95d4798b09e9f45a29dc53124b2a0b4c1dfc13",
     importpath = "github.com/phoreproject/bls",
 )
 

--- a/eth1/deposits.go
+++ b/eth1/deposits.go
@@ -45,7 +45,7 @@ func CreateDepositData(validatorKey []byte, withdrawalKey []byte, amountInGwei u
 		Amount:                amountInGwei,
 	}
 
-	sr, err := ssz.HashTreeRoot(di)
+	sr, err := ssz.SigningRoot(di)
 	if err != nil {
 		return nil, err
 	}

--- a/eth1/deposits.go
+++ b/eth1/deposits.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// MaxEffectiveBalance of an active eth2 validator.
-	MaxEffectiveBalance      = uint64(3.2 * 1e9)
+	MaxEffectiveBalance      = uint64(32 * 1e9)
 	blsWithdrawalPrefixByte  = byte(0)
 	domainDeposit            = [4]byte{3, 0, 0, 0}
 	genesisForkVersion       = []byte{0, 0, 0, 0}

--- a/main.go
+++ b/main.go
@@ -247,7 +247,6 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		copy(blockHash[:], blockHashBytes)
 		numByHash := s.eth1BlockNumbersByHash[blockHash]
 		block := s.eth1BlocksByNumber[numByHash]
-		block.Time = uint64(time.Now().Unix())
 		response := requestItem.response(block)
 		if err := codec.Write(ctx, response); err != nil {
 			log.Error(err)

--- a/main.go
+++ b/main.go
@@ -247,6 +247,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		copy(blockHash[:], blockHashBytes)
 		numByHash := s.eth1BlockNumbersByHash[blockHash]
 		block := s.eth1BlocksByNumber[numByHash]
+		block.Time = uint64(time.Now().Unix())
 		response := requestItem.response(block)
 		if err := codec.Write(ctx, response); err != nil {
 			log.Error(err)


### PR DESCRIPTION
This PR addresses the following:
- [x] Update prysm and go-ssz dependencies
- [x] Properly sign deposit data by doing signing root and then attaching a signature
- [x] Block time of blockByHash is set to time.Now() in the response for easier Prysm kickstarts
- [x] Use the right minimal effective balance