### PR TITLE
Add docker support and optionally disable interactive prompt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/prysmaticlabs/build-agent
+FROM gcr.io/prysmaticlabs/build-agent as builder
 
 COPY . /src
 WORKDIR /src
@@ -8,4 +8,9 @@ RUN bazel build //:eth1-mock-rpc
 EXPOSE 7777
 EXPOSE 7778
 
-ENTRYPOINT ["/src/bazel-bin/linux_amd64_stripped/eth1-mock-rpc"]
+FROM gcr.io/whiteblock/base:ubuntu1804
+
+COPY --from=builder /src/bazel-bin/linux_amd64_stripped/eth1-mock-rpc /usr/local/bin/
+
+
+ENTRYPOINT ["/usr/local/bin/eth1-mock-rpc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM gcr.io/prysmaticlabs/build-agent
+
+COPY . /src
+WORKDIR /src
+
+RUN bazel build //:eth1-mock-rpc
+
+EXPOSE 7777
+EXPOSE 7778
+
+ENTRYPOINT ["/src/bazel-bin/linux_amd64_stripped/eth1-mock-rpc"]

--- a/README.md
+++ b/README.md
@@ -80,5 +80,3 @@ bazel run //beacon-chain -- \
 ## License
 
 [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html)
-
-

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This project serves as a mock server that simulates that deposit functionality w
 
 ## Installation
 
-To run the tool, you'll need to install: 
+To run the tool, you'll need to install:
 
   - The latest release of [Bazel](https://docs.bazel.build/versions/master/install.html)
   - A modern GNU/Linux operating system
 
 ### Build the Mock ETH1 RPC Server
-
+#### Native
 1. Open a terminal window. Ensure you are running the most recent version of Bazel by issuing the command:
 ```
 bazel version
@@ -35,26 +35,10 @@ bazel build //...
 ```
 Bazel will automatically pull and install any dependencies as well, including Go and necessary compilers.
 
-### Build the Prysm Project
-
-
-## Docker:
-### Build
+#### Docker
 ```
-docker built -t eth1-mock-rpc .
-docker run --rm -it eth1-mock-rpc --help
-
-# NOTE: see prysmaticlabs/prysm repo for
-#       directions on how to generate keys
-
-docker run --rm \
-  -v <path-to-keys-dir>:/keys \
-  eth1-mock-rpc \
-    --unencrypted-keys-dir /keys \
-    --genesis-deposits 64 \
-    --prompt-for-deposit=false
+docker build -t eth1-mock-rpc .
 ```
-
 
 ## Running the Mock ETH1 RPC Server
 
@@ -68,6 +52,7 @@ bazel run //:eth1-mock-rpc -- --genesis-deposits 64 --unencrypted-keys /path/to/
 
 Once your server is running, it will launch an HTTP and websocket listener at http://localhost:7777 and http://localhost:7778 respectively. You can now launch the Prysm project and point it to these endpoints to receive mock data:
 
+#### Native
 ```sh
 bazel run //beacon-chain -- \
 --no-discovery \
@@ -75,6 +60,16 @@ bazel run //beacon-chain -- \
 --web3provider ws://localhost:7778 \
 --clear-db \
 --verbosity debug
+```
+
+#### Docker
+```
+docker run --rm \
+  -v <path-to-unencrypted-keys-dir>:/keys \
+  eth1-mock-rpc \
+    --unencrypted-keys-dir /keys \
+    --genesis-deposits 64 \
+    --prompt-for-deposit=false
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ Bazel will automatically pull and install any dependencies as well, including Go
 ### Build the Prysm Project
 
 
+## Docker:
+### Build
+```
+docker built -t eth1-mock-rpc .
+docker run --rm -it eth1-mock-rpc --help
+
+# NOTE: see prysmaticlabs/prysm repo for
+#       directions on how to generate keys
+
+docker run --rm \
+  -v <path-to-keys-dir>:/keys \
+  eth1-mock-rpc \
+    --unencrypted-keys-dir /keys \
+    --genesis-deposits 64 \
+    --prompt-for-deposit=false
+```
+
 
 ## Running the Mock ETH1 RPC Server
 

--- a/main.go
+++ b/main.go
@@ -47,6 +47,9 @@ var (
 	pprof              = flag.Bool("pprof", false, "Enable pprof")
 	unencryptedKeysDir = flag.String("unencrypted-keys-dir", "", "Path to directory of json files containing unencrypted validator private keys")
 	log                = logrus.WithField("prefix", "main")
+	// use this flag when running non-interactively
+	// otherwise, prompt will spam stdout
+	promptForDeposits  = flag.Bool("prompt-for-deposits", true, "Prompt user to trigger deposits")
 )
 
 type server struct {
@@ -172,7 +175,9 @@ func main() {
 	wsSrv := &http.Server{Handler: srv.ServeWebsocket()}
 	go wsSrv.Serve(wsListener)
 
-	go srv.listenForDepositTrigger()
+	if *promptForDeposits {
+		go srv.listenForDepositTrigger()
+	}
 
 	go srv.advanceEth1Chain(*blockTime)
 

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ const (
 var (
 	wsPort             = flag.String("ws-port", "7778", "Port on which to serve websocket listeners")
 	httpPort           = flag.String("http-port", "7777", "Port on which to serve http listeners")
+	host               = flag.String("host", "localhost", "Host on which to listen (default: localhost)")
 	numGenesisDeposits = flag.Int("genesis-deposits", 0, "Number of deposits to read from the keystore to trigger the genesis event")
 	blockTime          = flag.Int("block-time", 14, "Average time between blocks in seconds, default: 14s (Goerli testnet)")
 	verbosity          = flag.String("verbosity", "info", "Logging verbosity (debug, info=default, warn, error, fatal, panic)")
@@ -123,11 +124,11 @@ func main() {
 		)
 	}
 
-	httpListener, err := net.Listen("tcp", fmt.Sprintf("localhost:%s", *httpPort))
+	httpListener, err := net.Listen("tcp", fmt.Sprintf("%s:%s", *host, *httpPort))
 	if err != nil {
 		log.Fatal(err)
 	}
-	wsListener, err := net.Listen("tcp", fmt.Sprintf("localhost:%s", *wsPort))
+	wsListener, err := net.Listen("tcp", fmt.Sprintf("%s:%s", *host, *wsPort))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This diff adds a dockerfile and a optional command line flag to disable this prompt:
```
[2020-03-27 17:29:35]  INFO main: Enter the number of new eth2 deposits to trigger (max allowed 0):
>>
```

When I first dockerized this, I found that it sprayed out the prompt again and again, filling up the logs, so I added 